### PR TITLE
feat: Secretary, scaffolding for future messages, and cleanup

### DIFF
--- a/src/channel/coolholepoints.js
+++ b/src/channel/coolholepoints.js
@@ -298,7 +298,7 @@ class Coolpoints extends ChannelModule {
    * @param {Number} points User's coolpoints
    */
   subtract(name, points) {
-    this.set(name, this.get(name)?.points ?? 0 - points);
+    this.set(name, (this.get(name)?.points ?? 0) - points);
     this.dirty = true;
   }
 
@@ -519,7 +519,7 @@ class Coolpoints extends ChannelModule {
           `Wise spender ${user.getName()} spent ${pointsToSpend} points on ${action}`,
           new ReturnPointData(
             user.getName(),
-            pointsToSpend,
+            -pointsToSpend,
             this.get(user.getName()).points
           )
         )
@@ -639,7 +639,7 @@ class Coolpoints extends ChannelModule {
           `${user.getName()} lost ${pointsToLose} points for ${action}`,
           new ReturnPointData(
             user.getName(),
-            pointsToLose,
+            -pointsToLose,
             this.get(user.getName()).points
           )
         )

--- a/src/channel/coolholepoints.js
+++ b/src/channel/coolholepoints.js
@@ -5,6 +5,29 @@ var Flags = require("../flags");
 import { ActionType } from "./coolholepoints-actions-options";
 
 /**
+ * @typedef {Object} ActionResult
+ * @property {boolean} success - Indicates if the operation was successful.
+ * @property {string} message - Optional message detailing the result.
+ */
+class ActionResult {
+  constructor(success, message) {
+    this.success = success;
+    this.message = message;
+  }
+}
+
+/**
+ * @typedef {Object} ErrorObject
+ * @property {Object} user User information
+ * @property {String} callingFunction Function the error was caught in
+ * @property {String} returnSocket Event name to emit to
+ * @property {String} err Error string
+ * @property {Object} data Data related to the error
+ * @property {String} userMessage Message to display to the user
+ */
+
+/**
+ * @typedef {Object} PointData
  * @class PointData
  * @classdesc PointData class
  * @param {String} user user
@@ -17,6 +40,7 @@ class PointData {
     this.points = points;
   }
 }
+
 /**
  * @class ReturnPointData
  * @classdesc ReturnPointData class
@@ -125,8 +149,21 @@ class Coolpoints extends ChannelModule {
   }
 
   /**
+   * Checks if a user is eligible to use coolpoints
+   * @param {Object} user user object
+   * @returns {Boolean} if user is eligible for points
+   */
+  isUserEligibleForPoints(user) {
+    return (
+      user.channel.is(Flags.C_REGISTERED) &&
+      user.is(Flags.U_REGISTERED) &&
+      user.is(Flags.U_LOGGED_IN)
+    );
+  }
+
+  /**
    * Post join hook
-   * @param {*} user user object
+   * @param {Object} user user object
    */
   onUserPostJoin(user) {
     if (!user.channel.is(Flags.C_REGISTERED)) return;
@@ -134,6 +171,11 @@ class Coolpoints extends ChannelModule {
     user.socket.on(
       "applyPointsToUser",
       this.handleApplyPointsToUser.bind(this, user)
+    );
+
+    this.channel.modules.chat.registerCommand(
+      "/secretary",
+      this.handleSecretary.bind(this)
     );
 
     this.init(user);
@@ -146,21 +188,16 @@ class Coolpoints extends ChannelModule {
 
   /**
    * Generic Log Error wrapper
-   * @param {Object} errorObject Error information
-   * @param {Object} errorObject.user User information
-   * @param {String} errorObject.callingFunction Function the error was caught in
-   * @param {String} errorObject.returnSocket Event name to emit to
-   * @param {String} errorObject.err Error string
-   * @param {Object} errorObject.data Data related to the error
-   * @param {String} errorObject.userMessage Message to display to the user
+   * @param {ErrorObject} errorObject Error information
    */
-  logError({ user, callingFunction, returnSocket, err, data, userMessage }) {
+  logError(errorObject) {
+    const { user, callingFunction, data, returnSocket, userMessage } =
+      errorObject;
     LOGGER.error(
       `Exception caught in ${callingFunction} for CoolPoints. Here's hopefully relevant data: ${JSON.stringify(
         data ? data : {}
-      )} Error:  ${err}`
+      )} Error:  ${errorObject.err}`
     );
-
     if (returnSocket)
       // Return an empty array of point data... for now probably
       user.socket.emit(returnSocket, new ReturnMsg("error", userMessage, []));
@@ -231,12 +268,13 @@ class Coolpoints extends ChannelModule {
    */
   init(user) {
     if (
-      user.getName() && // User has a name
-      user.account.globalRank !== 0 && // Is not a guest
+      this.isUserEligibleForPoints(user) &&
+      user.getName() &&
       !this.exists(user.getName())
     ) {
       this.set(user.getName(), 0);
     }
+
     user.socket.emit(
       "coolpointsInitResponse",
       new ReturnMsg("success", "Here's everyones' points", this.coolpoints)
@@ -296,6 +334,18 @@ class Coolpoints extends ChannelModule {
    */
   handleApplyPointsToUser(user, data) {
     try {
+      if (!this.isUserEligibleForPoints(user)) {
+        this.logError({
+          user,
+          callingFunction: "applyPointsToUser",
+          returnSocket: "coolpointsFailure",
+          err: `User is not registered or logged in`,
+          data: user,
+          userMessage: `Error: You must join cause if you wish to participate.`,
+        });
+        return;
+      }
+
       const { targetName, points } = data;
       if (!this.canUpdateOthersPoints(user, "applyPointsToUser")) return;
 
@@ -344,7 +394,7 @@ class Coolpoints extends ChannelModule {
    * @param {String} action action to validate
    * @param {String} expectedActionType expected action type
    * @param {String} callingFunction calling function
-   * @returns boolean
+   * @returns {Boolean} if the action is valid
    */
   isValidAction(user, action, expectedActionType, callingFunction) {
     const pointData = this.get(user.getName());
@@ -368,7 +418,7 @@ class Coolpoints extends ChannelModule {
         returnSocket: "coolpointsFailure",
         err: `Action ${action} is not an ${expectedActionType}`,
         data: { user: user.getName(), action },
-        userMessage: `Error: Action ${action} is not an ${expectedActionType}`,
+        userMessage: `Error: This distrubance was felt. Your action was recorded.`,
       });
       return false;
     }
@@ -385,7 +435,7 @@ class Coolpoints extends ChannelModule {
           returnSocket: "coolpointsFailure",
           err: `Action ${action} is not enabled`,
           data: { user: user.getName(), action },
-          userMessage: `Error: Action ${action} is not enabled`,
+          userMessage: `Error: Action ${action} has been deemed too powerful. Has been disabled for now.`,
         });
       return false;
     }
@@ -403,7 +453,7 @@ class Coolpoints extends ChannelModule {
             returnSocket: "coolpointsFailure",
             err: `User ${user.getName()} does not have enough points to spend on ${action}`,
             data: { user: user.getName(), action },
-            userMessage: `Error: You do not have enough points to spend on ${action}`,
+            userMessage: `Error: You have not done enough for society to earn ${action}`,
           });
           return false;
         }
@@ -429,13 +479,24 @@ class Coolpoints extends ChannelModule {
    * @summary Spend coolpoints
    * @param {Object} user user object
    * @param {String} action action to spend points on
+   * @return {ActionResult} The result of the operation.
    */
   spend(user, action) {
     try {
-      if(!user.channel.is(Flags.C_REGISTERED) || !user.is(Flags.U_REGISTERED) || !user.is(Flags.U_LOGGED_IN)) return;
+      if (!this.isUserEligibleForPoints(user)) {
+        this.logError({
+          user,
+          callingFunction: "spend",
+          returnSocket: "coolpointsFailure",
+          err: `User ${user.getName()} is not registered or logged in`,
+          data: user.getName(),
+          userMessage: `Error: You must join cause if you wish to participate.`,
+        });
+        return new ActionResult(false, "User is not registered or logged in");
+      }
 
       if (!this.isValidAction(user, action, ActionType.Expenditures, "spend"))
-        return;
+        return new ActionResult(false, "Action is not valid");
 
       const actionData = this.channel.modules.coolholeactionspoints.get(action);
       const pointsToSpend = actionData.options.find(
@@ -463,6 +524,7 @@ class Coolpoints extends ChannelModule {
           )
         )
       );
+      return new ActionResult(true, "User spent points successfully");
     } catch (err) {
       this.logError({
         user,
@@ -472,6 +534,7 @@ class Coolpoints extends ChannelModule {
         data: user.getName(),
         userMessage: `Error: Unable to spend points. Let the head monkey in charge know`,
       });
+      return new ActionResult(false, "Unable to spend points. Unknown error");
     }
   }
 
@@ -479,13 +542,24 @@ class Coolpoints extends ChannelModule {
    * @summary Earn coolpoints
    * @param {Object} user user object
    * @param {String} action action was rewarded for
+   * @return {ActionResult} The result of the operation
    */
   earn(user, action) {
     try {
-      if(!user.channel.is(Flags.C_REGISTERED) || !user.is(Flags.U_REGISTERED) || !user.is(Flags.U_LOGGED_IN)) return;
+      if (!this.isUserEligibleForPoints(user)) {
+        this.logError({
+          user,
+          callingFunction: "earn",
+          returnSocket: "coolpointsFailure",
+          err: `User ${user.getName()} is not registered or logged in`,
+          data: user.getName(),
+          userMessage: `Error: You must join cause if you wish to participate.`,
+        });
+        return new ActionResult(false, "User is not registered or logged in");
+      }
 
       if (!this.isValidAction(user, action, ActionType.Earnings, "earn"))
-        return;
+        return new ActionResult(false, "Action is not valid");
 
       const actionData = this.channel.modules.coolholeactionspoints.get(action);
       const pointsToEarn = actionData.options.find(
@@ -510,6 +584,7 @@ class Coolpoints extends ChannelModule {
           )
         )
       );
+      return new ActionResult(true, "User earned points successfully");
     } catch (err) {
       this.logError({
         user,
@@ -519,6 +594,7 @@ class Coolpoints extends ChannelModule {
         data: user.getName(),
         userMessage: `Error: Unable to award points. Let the head monkey in charge know`,
       });
+      return new ActionResult(false, "Unable to earn points. Unknown error");
     }
   }
 
@@ -526,12 +602,24 @@ class Coolpoints extends ChannelModule {
    * @summary Lose coolpoints and allows users to go negative
    * @param {Object} user user object
    * @param {String} action action was penalized for
+   * @return {Object} object with success or failure and message
    */
   lose(user, action) {
     try {
-      if(!user.channel.is(Flags.C_REGISTERED) || !user.is(Flags.U_REGISTERED) || !user.is(Flags.U_LOGGED_IN)) return;
-      
-      if (!this.isValidAction(user, action, ActionType.Losses, "lose")) return;
+      if (!this.isUserEligibleForPoints(user)) {
+        this.logError({
+          user,
+          callingFunction: "lose",
+          returnSocket: "coolpointsFailure",
+          err: `User ${user.getName()} is not registered or logged in`,
+          data: user.getName(),
+          userMessage: `Error: You must join cause if you wish to participate.`,
+        });
+        return new ActionResult(false, "User is not registered or logged in");
+      }
+
+      if (!this.isValidAction(user, action, ActionType.Losses, "lose"))
+        return new ActionResult(false, "Action is not valid");
 
       const actionData = this.channel.modules.coolholeactionspoints.get(action);
       const pointsToLose = actionData.options.find(
@@ -556,6 +644,8 @@ class Coolpoints extends ChannelModule {
           )
         )
       );
+
+      return new ActionResult(true, "User lost points successfully");
     } catch (err) {
       this.logError({
         user,
@@ -565,6 +655,8 @@ class Coolpoints extends ChannelModule {
         data: user.getName(),
         userMessage: `Error: Unable to lose points. Let the head monkey in charge know`,
       });
+
+      return new ActionResult(false, "Unable to lose points. Unknown error");
     }
   }
 
@@ -595,10 +687,20 @@ class Coolpoints extends ChannelModule {
    * @returns {Object} chat message object with statuses applied
    */
   handleChatStatuses(user, chatObj) {
-    if(!user.channel.is(Flags.C_REGISTERED) || !user.is(Flags.U_REGISTERED) || !user.is(Flags.U_LOGGED_IN)) return;
-    
+    if (!this.isUserEligibleForPoints(user)) {
+      this.logError({
+        user,
+        callingFunction: "handleChatStatuses",
+        returnSocket: "coolpointsFailure",
+        err: `User ${user.getName()} is not registered or logged in`,
+        data: user.getName(),
+        userMessage: `Error: You must join cause if you wish to participate.`,
+      });
+      return;
+    }
+
     const statuses = this.checkStatuses(user);
-    let res = { ...chatObj };
+    let res = JSON.parse(JSON.stringify(chatObj));
     let filters = [];
     let attemptToApplyAd = false;
 
@@ -667,8 +769,8 @@ class Coolpoints extends ChannelModule {
   }
 
   /**
-   * @summary Handles the active earning action for logged in users. Runs on an interval and writes the interval userActiveIntervalIds keyed by the user's name + channel
-   * @param {*} user user object
+   * Handles the active earning action for logged in users. Runs on an interval and writes the interval userActiveIntervalIds keyed by the user's name + channel
+   * @param {Object} user user object
    */
   handleActive(user) {
     if (!user.is(Flags.U_REGISTERED) || !user.is(Flags.U_LOGGED_IN)) {
@@ -731,10 +833,47 @@ class Coolpoints extends ChannelModule {
     }, activeInterval);
   }
 
+  /**
+   * Clears interval and removes from userActiveIntervalIds
+   * @param {Object} user user object
+   */
   cleanUpActive(user) {
     LOGGER.info(`Clearing active interval for ${user.getName()}`);
     clearInterval(this.userActiveIntervalIds[user.getName()]);
     delete this.userActiveIntervalIds[user.getName()];
+  }
+
+  /**
+   * Handles the secretary command
+   * @param {Object} user user object
+   * @param {String} msg message
+   * @param {Object} meta meta object about the message
+   * @return {Object} object with success or failure and message
+   */
+  handleSecretary(user, msg, meta) {
+    if (!this.isUserEligibleForPoints(user)) {
+      this.logError({
+        user,
+        callingFunction: "handleSecretary",
+        returnSocket: "coolpointsFailure",
+        err: `User ${user.getName()} is not registered or logged in`,
+        data: user.getName(),
+        userMessage: `Error: You must join cause if you wish to participate.`,
+      });
+      return new ActionResult(false, "User is not registered or logged in");
+    }
+
+    if (!this.spend(user, "secretary").success)
+      return new ActionResult(false, "Unable to spend for secretary");
+
+    meta.addClass = "secretary";
+
+    const msgWithoutCmd = msg.split(" ").slice(1).join(" ");
+    this.channel.modules.chat.processChatMsg(user, {
+      msg: msgWithoutCmd,
+      meta,
+    });
+    return new ActionResult(true, "Secretary command successful");
   }
 }
 

--- a/templates/channel.pug
+++ b/templates/channel.pug
@@ -251,11 +251,12 @@ html(lang="en")
               +chanlog()
               +permeditor()
               include coolhole-coolpoints
-              +coolpointoptions()
-              +coolpointsusertable()
+              +ch-coolpointoptions()
+              +ch-coolpointsusertable()
           .modal-footer
             button.btn.btn-default(type="button", data-dismiss="modal") Close
-    +coolpointsuserprompt()
+    +ch-coolpointsuserprompt()
+    +ch-command-modal("Secretary")
     #ch-chatoptions.modal.fade(tabindex="-1", role="dialog", aria-hidden="true")
       .modal-dialog.modal-dialog-nonfluid
         .modal-content 

--- a/templates/coolhole-coolpoints.pug
+++ b/templates/coolhole-coolpoints.pug
@@ -1,4 +1,4 @@
-mixin coolpointoptions
+mixin ch-coolpointoptions
   #cs-chancoolpoint-options.tab-pane.fade.col-12(role="tabpanel", aria-labelledby="csCoolpointsOptionsTab")
     .form-group.table.mb-3.mb-sm-2.px-4
         each type in cpOptsTypes
@@ -33,7 +33,7 @@ mixin coolpointoptions
                                         default 
                                             break
 
-mixin coolpointsusertable
+mixin ch-coolpointsusertable
   #cs-chancoolpoint-user-table.tab-pane.fade.col-12(role="tabpanel", aria-labelledby="csCoolpointsUserTableTab")
     h4 Coolpoints Users Table
       form.form-inline
@@ -52,7 +52,7 @@ mixin coolpointsusertable
             th Fate
         tbody
 
-mixin coolpointsuserprompt
+mixin ch-coolpointsuserprompt
     #coolPointsPrompt.modal.fade(role="dialog", aria-hidden="true", tabindex="-1")
       .modal-dialog.modal-lg(role="document")
         .modal-content
@@ -220,3 +220,40 @@ mixin legal-nonsense
     b Contact Information
     p If you have any questions or concerns about these terms, please contact us at forgotmycockli@protonmail.com.
 
+// TODO: Create a general coolhole pug file
+
+mixin ch-command-modal(title)
+  - var modalId = `ch-${title.toLowerCase().replace(/\s/g, "-")}-modal`;
+  .modal.fade(id=modalId, tabindex="-1", role="dialog", aria-hidden="true")
+      .modal-dialog.modal-dialog-nonfluid
+        .modal-content 
+          .modal-header
+            button.close(data-dismiss="modal", aria-hidden="true") &times;
+            h4= title
+          .modal-body(id=`${modalId}-body`)
+            case title
+              when "Secretary"
+                +ch-secretary-modal-body
+              default
+                p No content. Ask a monkey incharge
+          .modal-footer(id=`${modalId}-footer`)
+            case title
+              when "Secretary"
+                +ch-secretary-modal-footer
+              default
+                p No content. Ask a monkey incharge
+
+mixin ch-secretary-modal-body
+  h4 Provide the script and she will let the world know
+  form.form-horizontal(action="javascript:void(0)")
+    +textbox-auto("secretaryOption-rate", "Rate", "1.2")
+    +textbox-auto("secretaryOption-pitch", "Pitch", "1")
+    label.control-label.col-sm-4(for="#secretaryOption-voice") Voice
+    .col-sm-8
+      select#secretaryOption-voice.form-control
+      p.text-danger Voices are specific to your browser. If a voice is not available for a user, the default voice will be used.
+    +textbox-auto("secretaryOption-message", "Message")
+
+mixin ch-secretary-modal-footer 
+  button.btn.btn-primary(type="button", data-dismiss="modal") Abort
+  button#secretaryOption-send-btn.btn.btn-primary(type="button", data-dismiss="modal") Send

--- a/templates/coolhole-coolpoints.pug
+++ b/templates/coolhole-coolpoints.pug
@@ -246,13 +246,13 @@ mixin ch-command-modal(title)
 mixin ch-secretary-modal-body
   h4 Provide the script and she will let the world know
   form.form-horizontal(action="javascript:void(0)")
-    +textbox-auto("secretaryOption-rate", "Rate", "1.2")
-    +textbox-auto("secretaryOption-pitch", "Pitch", "1")
+    +textbox("secretaryOption-rate", "Rate", "1.2")
+    +textbox("secretaryOption-pitch", "Pitch", "1")
     label.control-label.col-sm-4(for="#secretaryOption-voice") Voice
     .col-sm-8
       select#secretaryOption-voice.form-control
       p.text-danger Voices are specific to your browser. If a voice is not available for a user, the default voice will be used.
-    +textbox-auto("secretaryOption-message", "Message")
+    +textbox("secretaryOption-message", "Message")
 
 mixin ch-secretary-modal-footer 
   button.btn.btn-primary(type="button", data-dismiss="modal") Abort

--- a/www/css/coolhole.css
+++ b/www/css/coolhole.css
@@ -612,3 +612,107 @@
   color: #d22f29; /* Replace with less */
   border: 1px solid #d22f29; /* Replace with less */
 }
+
+.secretary {
+  position: fixed;
+  pointer-events: none;
+  z-index: 11;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  gap: 10px;
+  font-size: 72px;
+}
+
+.secretary-message {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Rainbow effect on 'european' anywhere in the special chat message */
+.secretary .text-lottery[data-text*="european"],
+.danmu .text-lottery[data-text*="european"] {
+  -webkit-animation: rainbow 0.5s;
+  animation: rainbow 0.5s;
+  -webkit-animation-iteration-count: infinite;
+  animation-iteration-count: infinite;
+}
+
+/* Add a shadow to the text only when not gold */
+.secretary span:not(.text-lottery),
+.danmu span:not(.text-lottery) {
+  text-shadow: 1px 1px #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000;
+  letter-spacing: 0.2px;
+}
+
+.focus-in-blur-out-expand {
+  -webkit-animation: text-focus-in 0.5s cubic-bezier(0.55, 0.085, 0.68, 0.53)
+      both,
+    blur-out-expand 1s cubic-bezier(0.25, 0.46, 0.45, 0.94) 5s both;
+  animation: text-focus-in 0.5s cubic-bezier(0.55, 0.085, 0.68, 0.53) both,
+    blur-out-expand 1s cubic-bezier(0.25, 0.46, 0.45, 0.94) 5s both;
+}
+
+@-webkit-keyframes blur-out-expand {
+  0% {
+    -webkit-filter: blur(0.01);
+    filter: blur(0.01);
+  }
+
+  100% {
+    letter-spacing: 1em;
+    -webkit-filter: blur(12px) opacity(0%);
+    filter: blur(12px) opacity(0%);
+  }
+}
+
+@keyframes blur-out-expand {
+  0% {
+    -webkit-filter: blur(0.01);
+    filter: blur(0.01);
+  }
+
+  100% {
+    letter-spacing: 1em;
+    -webkit-filter: blur(12px) opacity(0%);
+    filter: blur(12px) opacity(0%);
+  }
+}
+
+@-webkit-keyframes text-focus-in {
+  0% {
+    -webkit-filter: blur(12px);
+    filter: blur(12px);
+    opacity: 0;
+  }
+
+  100% {
+    -webkit-filter: blur(0px);
+    filter: blur(0px);
+    opacity: 1;
+  }
+}
+
+@keyframes text-focus-in {
+  0% {
+    -webkit-filter: blur(12px);
+    filter: blur(12px);
+    opacity: 0;
+  }
+
+  100% {
+    -webkit-filter: blur(0px);
+    filter: blur(0px);
+    opacity: 1;
+  }
+}

--- a/www/css/coolhole.css
+++ b/www/css/coolhole.css
@@ -82,7 +82,9 @@
 }
 
 /* Rainbow effect on 'european' anywhere in the chat message */
-#messagebuffer [data-text*="european"] {
+#messagebuffer [data-text*="european"],
+.danmu [data-text*="european"],
+.secretary [data-text*="european"] {
   -webkit-animation: rainbow 5;
   -moz-animation: rainbow 5s;
   -ms-animation: rainbow 5s;

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -191,17 +191,6 @@ function parseSpecialChatMessage(msg) {
 // ============================================================
 // Secretary
 // ============================================================
-const SEC_MSG_INPUT = $("#secretaryOption-message");
-const SEC_PITCH_INPUT = $("#secretaryOption-pitch");
-const SEC_RATE_INPUT = $("#secretaryOption-rate");
-const SEC_VOICE_INPUT = $("#secretaryOption-voice");
-// Populate the voice options
-voices.forEach((voice) => {
-  $("<option/>")
-    .val(voice.name)
-    .text(voice.name)
-    .appendTo(SEC_VOICE_INPUT);
-});
 
 
 /**

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -387,7 +387,7 @@ function processSpeechMessage(chatMessage) {
   const defaultSpeechObj = {
     rate: 1.2,
     pitch: 1,
-    voiceObj: voiceObj: voices.find((voice) => voice.default) ?? voices[0],
+    voiceObj: voices.find((voice) => voice.default) ?? voices[0],
     message: chatMessage,
   };
 

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -183,6 +183,13 @@ const SEC_MSG_INPUT = $("#secretaryOption-message");
 const SEC_PITCH_INPUT = $("#secretaryOption-pitch");
 const SEC_RATE_INPUT = $("#secretaryOption-rate");
 const SEC_VOICE_INPUT = $("#secretaryOption-voice");
+// Populate the voice options
+voices.forEach((voice) => {
+  $("<option/>")
+    .val(voice.name)
+    .text(voice.name)
+    .appendTo(SEC_VOICE_INPUT);
+});
 
 
 /**
@@ -206,14 +213,6 @@ function coolholeMessageOverride(msg, meta) {
           true
         );
     }
-
-    // Populate the voice options
-    voices.forEach((voice) => {
-      $("<option/>")
-        .val(voice.name)
-        .text(voice.name)
-        .appendTo("#secretaryOption-voice");
-    });
 
     // Unbind and rebind the click event to prevent multiple event bindings
     $("#secretaryOption-send-btn")

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -315,11 +315,12 @@ function secretaryMessageCallback(data) {
     // Create the utterance object for the message with modified rate/pitch/voice/message
     const utterThis = new SpeechSynthesisUtterance(speechObj.message);
 
-    if (speechObj.voiceObj) {
+    if (speechObj.voiceObj) 
       utterThis.voice = speechObj.voiceObj;
+    if (speechObj.rate)
       utterThis.rate = speechObj.rate;
+    if (speechObj.pitch)
       utterThis.pitch = speechObj.pitch;
-    }
 
     // If there any sounds in the array...
     if (sounds && sounds.length > 0) {

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -5,6 +5,26 @@
  */
 
 /**
+ * ============================================================
+ * Globals
+ * ============================================================
+ */
+const synth = window.speechSynthesis;
+let voices = [];
+function populateVoiceList() {
+  voices = synth.getVoices();
+  // If we ever wanna give users a UI for what voices are available, they can select it here
+  // Probably won't translate between different browsers but w/e
+}
+
+if (speechSynthesis.onvoiceschanged !== undefined) {
+  speechSynthesis.onvoiceschanged = populateVoiceList;
+}
+
+//populate voices array initially.
+populateVoiceList();
+
+/**
  * Additional logic after the chat message div is created, but before its appended to the #messagebuffer, such as additional css classes.
  * @param {Object} data chat message object
  * @param {Object} last LASTCHAT object
@@ -72,6 +92,335 @@ function isMessageTooOld(msgTime) {
     messageTime.setSeconds(messageTime.getSeconds() + 5);
     return new Date() >= messageTime;
 }
+
+/**
+ * Determines if the chat message should be displayed out of the usual buffer.
+ * Avoids formatting to place message in buffer
+ * @param {Object} data message data
+ * @returns {Boolean} if the message should be displayed out of the buffer
+ */
+function coolholeShouldShowMessageOutOfBuffer(data) {
+  if (data.meta.addClass === "secretary" || data.meta.addClass === "danmu") {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Handle message outside of buffer
+ * @param {Object} data message data
+ */
+function coolholeHandleMessageOutOfBuffer(data) {
+  if (data.meta.addClass === "secretary") {
+    secretaryMessageCallback(data);
+  } else if (data.meta.addClass === "danmu") {
+    danmuMessageCallback(data);
+  }
+}
+
+//-----------------------------------------------------------
+// [START] Special Chat Messages
+//-----------------------------------------------------------
+
+/**
+ * Certain commands require overriding the default message send behavior (ie: showing a modal first to accept parameters for a command)
+ * @param {String} msg
+ * @returns {Boolean} true = override message send. false = do not override message send.
+ */
+function coolholeShouldOverrideMessageSend(msg) {
+  const msgLower = msg.toLowerCase();
+  const commands = ["/secretary"];
+  if (commands.some((command) => msgLower.startsWith(command))) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Expects a "secretary" command with options in the message and returns the message and its options.
+ * EG: /secretary {-r 1.2 -p 3.4 -v "Microsoft Zira - English (United States)"} this is my message.
+ * @param {String} msg message to parse
+ * @returns {Object} obj  Return object eg: { msg: "this is my message", options: { rate: 1.2, pitch: 3.4, voice: "Microsoft Zira - English (United States)" } } 
+ * @returns {String} obj.msg the message to say
+ * @returns {Object} obj.options the options for the message
+ */
+function parseSecretaryMessage(msg) {
+  const commandRegex = /(\/\w+)?\s*(\{.*\})?\s+(.*$)?/i;
+  const match = msg.match(commandRegex);
+  if (!match) return { msg: "", options: {} };
+
+  const [_fullMatch, _command, flags, messageToSay] = msg.match(commandRegex);
+  if (!flags) return { msg: messageToSay, options: {} };
+
+  const flagRegex = /-(\w)\s+((\".+\")|[^\s]+)/gi;
+  let options = {};
+  [...flags.matchAll(flagRegex)].forEach((match) => {
+    const [_fullMatchFlag, flag, value] = match;
+    options[flag] = value.replaceAll('"', "");
+  });
+  return { msg: messageToSay, options };
+}
+
+/**
+ * Parses a special chat message and returns the message and its options.
+ * @param {String} msg Message to parse
+ * @returns {Object} obj Return object eg: { msg: "this is my message", options: { rate: 1.2, pitch: 3.4, voice: "Microsoft Zira - English (United States)" } } 
+ * @returns {String} obj.msg the message to use
+ * @returns {Object} obj.options the options for the message
+ */
+function parseSpecialChatMessage(msg) {
+  const msgLower = msg.toLowerCase();
+  if (msgLower.startsWith("/secretary")) {
+    return parseSecretaryMessage(msg);
+  }
+  return { msg, options: {} };
+}
+
+// ============================================================
+// Secretary
+// ============================================================
+const SEC_MSG_INPUT = $("#secretaryOption-message");
+const SEC_PITCH_INPUT = $("#secretaryOption-pitch");
+const SEC_RATE_INPUT = $("#secretaryOption-rate");
+const SEC_VOICE_INPUT = $("#secretaryOption-voice");
+
+
+/**
+ * Overrides the default message send behavior (ie: showing a modal first to accept parameters for a command)
+ * @param {String} msg Message to send
+ * @param {Object} meta Metadata of the message
+ */
+function coolholeMessageOverride(msg, meta) {
+  const msgLower = msg.toLowerCase();
+  if (msgLower.startsWith("/secretary")) {
+    // Prepopulate the message with the commands if provided in the message; otherwise use defaults
+    const { msg: parsedMessage, options } = parseSecretaryMessage(msg);
+    if (parsedMessage) SEC_MSG_INPUT.val(parsedMessage);
+    if (options["p"]) SEC_PITCH_INPUT.val(options["p"]);
+    if (options["r"]) SEC_RATE_INPUT.val(options["r"]);
+    if (options["v"]) {
+      const voiceFound = voices.some((voice) => voice.name === options["v"]);
+      if (voiceFound)
+        $(`#secretaryOption-voice option[value="${options["v"]}"]`).prop(
+          "selected",
+          true
+        );
+    }
+
+    // Populate the voice options
+    voices.forEach((voice) => {
+      $("<option/>")
+        .val(voice.name)
+        .text(voice.name)
+        .appendTo("#secretaryOption-voice");
+    });
+
+    // Unbind and rebind the click event to prevent multiple event bindings
+    $("#secretaryOption-send-btn")
+      .off("click")
+      .on("click", function () {
+        const msg = SEC_MSG_INPUT.val();
+        const pitch = SEC_PITCH_INPUT.val();
+        const rate = SEC_RATE_INPUT.val();
+        const voice = SEC_VOICE_INPUT.val();
+
+        let msgWithOptions = "/secretary";
+        if (pitch || rate || voice) {
+          msgWithOptions += " {";
+          if (pitch) {
+            msgWithOptions += `-p ${pitch} `;
+          }
+          if (rate) {
+            msgWithOptions += `-r ${rate} `;
+          }
+          if (voice) {
+            msgWithOptions += `-v "${voice}"`;
+          }
+          msgWithOptions += "}";
+        }
+        msgWithOptions += ` ${msg}`;
+        socket.emit("chatMsg", {
+          msg: msgWithOptions,
+          meta: meta,
+        });
+      });
+
+    $("#ch-secretary-modal").modal();
+  }
+  CHATHIST.push($("#chatline").val());
+  CHATHISTIDX = CHATHIST.length;
+  $("#chatline").val("");
+}
+
+/**
+ *
+ * @param {*} data
+ * @returns
+ */
+function secretaryMessageCallback(data) {
+  // TODO: Would be cool if we could stop the user from spending money if a secretary was currently active. oh well
+  if ($(".secretary").length > 0) {
+    $(".secretary").remove();
+  }
+  if (isMessageTooOld(data.time)) return; // Don't show the message if it's too old
+
+  // Elements to put things in
+  let div = $("<div/>");
+  let name = $("<span/>");
+
+  // Create user name
+  $("<strong/>")
+    .addClass("username")
+    .text(data.username + ": ")
+    .appendTo(name);
+  name.appendTo(div);
+
+  // Build message
+  let messageSpan = $("<span/>")
+    .addClass("secretary-message") // To prevent word wrap
+    .attr("data-text", data.msg) // To handle european
+    .appendTo(div);
+  let chatMessage = data.msg;
+
+  // Allows for emotes
+  chatMessage = stripImages(chatMessage);
+  chatMessage = execEmotes(chatMessage);
+  chatMessage = chatMessage.replace(/(\{.*\}\s+)*/, ""); // Remove options from displayed message
+  messageSpan[0].innerHTML = chatMessage;
+
+  /*
+    TODO: Pretty janky...
+    Apply function specific classes to wrapping div
+    Apply text-lottery or anything else to the message itself   
+    */
+  // position/font class + blur in animation
+  div.addClass("secretary focus-in-blur-out-expand");
+  // Any other class
+  messageSpan.addClass(data.meta.coolholeMeta.otherClasses.join(" "));
+
+  // Pulled from formatMessage; this controls just about all of the custom js like golds and soy
+  var safeUsername = data.username.replace(/[^\w-]/g, "\\$");
+  div.addClass("chat-msg-" + safeUsername);
+  div.appendTo("#main");
+
+  // Play special emote sounds and filter out any falsey values (ie: undef)
+  const sounds = emoteSound(div, safeUsername, "secretary").filter(Boolean);
+
+  // If we can do TTS and the text isn't empty...
+  if ("speechSynthesis" in window && data.msg.trim() !== "") {
+    // Create speechObj's rate/pitch/voice/message if there is any option in the message.
+    // TODO: Embed these option in some object on the callback rather than rely on string parsing
+    const speechObj = processSpeechMessage(data.msg);
+
+    // Create the utterance object for the message with modified rate/pitch/voice/message
+    const utterThis = new SpeechSynthesisUtterance(speechObj.message);
+
+    if (speechObj.voiceObj) {
+      utterThis.voice = speechObj.voiceObj;
+      utterThis.rate = speechObj.rate;
+      utterThis.pitch = speechObj.pitch;
+    }
+
+    // If there any sounds in the array...
+    if (sounds && sounds.length > 0) {
+      // Wait for all sounds to end; prepare for over-engineering
+      // Since we don't know when they start, we can't rely on the duration
+
+      // Setup a count to prevent a runaway interval
+      let intervalCount = 0;
+      // Interval function that either bails if all sounds have ended or we've called it too many times
+      function checkIfAllSoundHaveEnded(sounds) {
+        // We hit our threshold; stop waiting
+        if (intervalCount > 50) {
+          console.error(
+            "formatSecretaryMessage: sound interval never ended; hit interval count threshold",
+            sounds
+          );
+          window.speechSynthesis.speak(utterThis);
+          clearInterval(interval);
+        }
+        // Some sound is still going; keep waiting
+        if (sounds.some((sound) => !sound.ended)) {
+          intervalCount++;
+          return;
+        }
+        // All sounds have ended
+        console.log("All sounds ended; let's bail");
+        window.speechSynthesis.speak(utterThis);
+        clearInterval(interval);
+      }
+
+      // Begin interval with a check every 100ms
+      const interval = setInterval(function () {
+        checkIfAllSoundHaveEnded(sounds);
+      }, 100);
+    }
+    // If there are no sounds, ignore all the complicated shit above
+    else {
+      window.speechSynthesis.speak(utterThis);
+    }
+  }
+  // Delete when animation is finished
+  setTimeout(() => div.remove(), 7000);
+}
+
+/* 
+This function reads the chatMessage and modifies the speechObj based on flags in the chatMessage.
+It expects the flags to be between curly brackets {}.
+-r = rate of the speech. The units expected are decimal/integer. If it can't be parsed, default is 1.2.
+-p = pitch of the speech. The units expected are decimal/integer. If it can't be parsed, decault is 1.
+-v = voice. A string is expected. If it can't be found, Microsoft Zira - English (United States) is the default.
+
+It also strips out the {}'s out of the chatMessage and puts the results in speechObj.message.
+
+Example:
+	chatMessage:
+	/secretary {-r 1.2 -p 3.4 -v "Microsoft Zira - English (United States)"} this is my message.
+
+	speechObj.rate = 1.2
+	speechObj.pitch = 3.4
+	speechObj.voiceObj = (voice object from voices array)
+	speechObj.message = "this is my message."
+*/
+function processSpeechMessage(chatMessage) {
+  const defaultSpeechObj = {
+    rate: 1.2,
+    pitch: 1,
+    voiceObj: voices.find(
+      (voice) => voice.name === "Microsoft Zira - English (United States)"
+    ),
+    message: chatMessage,
+  };
+
+  if (!/\{.*\}/.test(chatMessage)) return defaultSpeechObj;
+
+  const { msg: speechMessage, options } = parseSecretaryMessage(chatMessage);
+
+  const speechObj = {
+    rate: options["r"] ? Number(options["r"]) : defaultSpeechObj.rate,
+    pitch: options["p"] ? Number(options["p"]) : defaultSpeechObj.pitch,
+    voiceObj: voices.find(
+      (voice) =>
+        voice.name.toLowerCase().includes(options["v"].toLowerCase()) ||
+        voice.name === options["v"]
+    ),
+    message: speechMessage,
+  };
+
+  return speechObj;
+}
+
+// ============================================================
+// Danmu
+// ============================================================
+
+function danmuMessageCallback(data) {
+  // TODO
+}
+
+//-----------------------------------------------------------
+// [END] Special Chat Messages
+//-----------------------------------------------------------
 
 //-----------------------------------------------------------
 // [START] CHAT OPTIONS MODAL

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -9,12 +9,24 @@
  * Globals
  * ============================================================
  */
+const SEC_MSG_INPUT = $("#secretaryOption-message");
+const SEC_PITCH_INPUT = $("#secretaryOption-pitch");
+const SEC_RATE_INPUT = $("#secretaryOption-rate");
+const SEC_VOICE_INPUT = $("#secretaryOption-voice");
+
 const synth = window.speechSynthesis;
 let voices = [];
 function populateVoiceList() {
-  voices = synth.getVoices();
-  // If we ever wanna give users a UI for what voices are available, they can select it here
-  // Probably won't translate between different browsers but w/e
+ voices = synth.getVoices();
+ // If we ever wanna give users a UI for what voices are available, they can select it here
+ // Probably won't translate between different browsers but w/e
+ 
+ // Clear out the secretary voices select
+ SEC_VOICE_INPUT.empty();
+ // Add the voices to the secretary voices select
+ voices.forEach((voice) => {
+   $("<option/>").val(voice.name).text(voice.name).appendTo(SEC_VOICE_INPUT);
+ });
 }
 
 if (speechSynthesis.onvoiceschanged !== undefined) {

--- a/www/js/coolhole-util.js
+++ b/www/js/coolhole-util.js
@@ -386,9 +386,7 @@ function processSpeechMessage(chatMessage) {
   const defaultSpeechObj = {
     rate: 1.2,
     pitch: 1,
-    voiceObj: voices.find(
-      (voice) => voice.name === "Microsoft Zira - English (United States)"
-    ),
+    voiceObj: voiceObj: voices.find((voice) => voice.default) ?? voices[0],
     message: chatMessage,
   };
 

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -148,6 +148,18 @@ function chatTabComplete(chatline) {
         options.push(emote.name);
     });
 
+    // Coolhole addition to add commands to tab completion
+    CHANNEL.opts.cpOpts
+      .map(
+        (opt) =>
+          opt.options.find((option) => option.optionName === "command")
+            ?.optionValue
+      )
+      .filter(Boolean)
+      .forEach(function (command) {
+        options.push(command);
+      });
+
     var method = USEROPTS.chat_tab_method;
     if (!CyTube.tabCompleteMethods[method]) {
         console.error("Unknown chat tab completion method '" + method + "', using default");
@@ -184,6 +196,11 @@ $("#chatline").on('keydown', function(ev) {
             if (CLIENT.rank >= 2 && msg.indexOf("/m ") === 0) {
                 meta.modflair = CLIENT.rank;
                 msg = msg.substring(3);
+            }
+
+            if (coolholeShouldOverrideMessageSend(msg)) {
+                coolholeMessageOverride(msg, meta);
+                return;
             }
 
             socket.emit("chatMsg", {

--- a/www/js/util.js
+++ b/www/js/util.js
@@ -1580,6 +1580,12 @@ function addChatMessage(data) {
     } else {
         LASTCHAT.time = data.time;
     }
+    
+    // Coolhole addition to render special message out of typical chat buffer
+    if (coolholeShouldShowMessageOutOfBuffer(data)) {
+        coolholeHandleMessageOutOfBuffer(data);
+        return;
+    }
 
     var msgBuf = $("#messagebuffer");
     var div = formatChatMessage(data, LASTCHAT);


### PR DESCRIPTION
# What was added

## Secretary 
- `/secretary` and the subsequent flags `-r`, `-p`, and `-v` should all be respected
- Added a modal when sending the command to make verifying your options (or adding them) easier:
![image](https://github.com/user-attachments/assets/1a5dfb33-c59c-4e3d-9387-927db06493e6)
_Handles both when the user provides the flags in the message (and subsequently pre-populates them) or leaves them blank_

## `ch-command-modal` mixin
- Should allow for us to reduce some boilerplate if we need to add new modals for additional commands
- Example invocation: `+ch-command-modal("Secretary")`

# What was changed (CyTube core)

## `$("#chatline").on('keydown'...)` in `ui.js`
- Added two new functions `coolholeShouldOverrideMessageSend` and `coolholeMessageOverride`
- Needed these since we had to intercept **outgoing** messages and display a modal if it's a specific CH command

## `addChatMessage` in `utils.js`
- Added two new functions `coolholeShouldShowMessageOutOfBuffer` and `coolholeHandleMessageOutOfBuffer`
- Needed these since we had to intercept **incoming** messages so they don't render inside the message buffer

## `chatTabComplete` in `ui.js`
- Added CH commands to the list of tab complete options

## General use of Coolhole specific `mixin`s
- Trying to standardize all CH mixins with `ch-` prefixed so it'll be easier to identify what's CH specific

# What was changed (Coolhole)

## `Coolpoints` server class
- Added `ActionResult` as a generic return object to hopefully easily describe if an action went through and if it didn't, why not
  - Subsequently spent way too much time trying to get proper JSDoc formatting to show a return object but I don't think it worked...
- Added `isUserEligibleForPoints` to reduce some repetition
-

## `processSpeechMessage` in `coolhole-utils.js`
- Wrote a `parseSecretaryMessage` to parse an incoming message with regex instead since I had to do that to pre-populate the new modal anyway
  - ⚠I'd like to find a way to send this info to the server (and receive it from the server) via a true JS object instead of parsing strings on either end
  - Could use the coolhole meta object some how...

# Tested...
- [X] Gold
- [X] European
- [X] European Gold
- [X] No commands
- [X] Only one of each command
- [X] Only message
- [X] All commands + no message
  - Expected behavior is kinda weird here since I can't reasonably assume someone wouldn't pass `{` and `}` in a message so I just assume they want the flag object as the message
  - This is more so a limitation of the command syntax since the message is technically in the same "grammar" as the flags (a message can be any string and a flag object is a specific string or not there at all)
- [X] Sending multiple secretary commands after one another
- [X] Attempting secretary with insufficient funds 


--- 
I hopefully haven't updated formatting on any pages. I installed prettier and have been tempted to add a config file to the project to keep everything uniform but, I don't want to risk mass updating existing CyTube core files with white space changes...