### PR TITLE
fix: change screen breakpoints

### DIFF
--- a/www/css/themes/less/shale/shale.less
+++ b/www/css/themes/less/shale/shale.less
@@ -564,4 +564,4 @@ input[type="checkbox"] {
 #plonotification > div > .btn {
   border: none;
   background-color: #742c00;
-
+}

--- a/www/css/themes/less/shale/shale.less
+++ b/www/css/themes/less/shale/shale.less
@@ -85,7 +85,32 @@ svg {
     padding-left: 10px;
     align-content: center;
   }
+}
 
+/* Navbar is transparent by default */
+.navbar.navbar-inverse.navbar-transparent {
+  transition: background-color 150ms;
+  background-color: transparent;
+}
+
+/*... but is solid when scrolled */
+.navbar.navbar-inverse.navbar-solid {
+  transition: background-color 150ms;
+  background-color: #070A12;
+}
+
+/* Nabbar becomes a dropdown at a specific breakpoint; make it no longer transparent */
+#nav-collapsible.collapse.in,
+#nav-collapsible.collapsing {
+  background-color: #070A12;
+  max-height: 100%;
+}
+
+/* Overriding bootstrap shitty defaults */
+.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:hover,
+.navbar-inverse .navbar-nav .open .dropdown-menu>li>a:focus {
+  background-color: #f5f5f5;
+  color: #212A2E;
 }
 
 .nav.nav-tabs {

--- a/www/css/themes/less/shale/variables.less
+++ b/www/css/themes/less/shale/variables.less
@@ -282,21 +282,21 @@
 
 // Small screen / tablet
 //** Deprecated `@screen-sm` as of v3.0.1
-@screen-sm:                  768px;
+@screen-sm:                  1100px;
 @screen-sm-min:              @screen-sm;
 //** Deprecated `@screen-tablet` as of v3.0.1
 @screen-tablet:              @screen-sm-min;
 
 // Medium screen / desktop
 //** Deprecated `@screen-md` as of v3.0.1
-@screen-md:                  992px;
+@screen-md:                  1200px;
 @screen-md-min:              @screen-md;
 //** Deprecated `@screen-desktop` as of v3.0.1
 @screen-desktop:             @screen-md-min;
 
 // Large screen / wide desktop
 //** Deprecated `@screen-lg` as of v3.0.1
-@screen-lg:                  1200px;
+@screen-lg:                  1920px;
 @screen-lg-min:              @screen-lg;
 //** Deprecated `@screen-lg-desktop` as of v3.0.1
 @screen-lg-desktop:          @screen-lg-min;

--- a/www/css/themes/shale.css
+++ b/www/css/themes/shale.css
@@ -1097,7 +1097,7 @@ p {
   font-weight: 300;
   line-height: 1.4;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .lead {
     font-size: 21px;
   }
@@ -1243,7 +1243,7 @@ dt {
 dd {
   margin-left: 0;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .dl-horizontal dt {
     float: left;
     width: 160px;
@@ -1377,17 +1377,17 @@ pre code {
   padding-left: 15px;
   padding-right: 15px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .container {
     width: 750px;
   }
 }
-@media (min-width: 992px) {
+@media (min-width: 1200px) {
   .container {
     width: 970px;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .container {
     width: 1170px;
   }
@@ -1622,7 +1622,7 @@ pre code {
 .col-xs-offset-0 {
   margin-left: 0%;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .col-sm-1,
   .col-sm-2,
   .col-sm-3,
@@ -1791,7 +1791,7 @@ pre code {
     margin-left: 0%;
   }
 }
-@media (min-width: 992px) {
+@media (min-width: 1200px) {
   .col-md-1,
   .col-md-2,
   .col-md-3,
@@ -1960,7 +1960,7 @@ pre code {
     margin-left: 0%;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .col-lg-1,
   .col-lg-2,
   .col-lg-3,
@@ -2324,7 +2324,7 @@ table th[class*="col-"] {
   overflow-x: auto;
   min-height: 0.01%;
 }
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 1099px) {
   .table-responsive {
     width: 100%;
     margin-bottom: 15px;
@@ -2737,7 +2737,7 @@ select[multiple].form-group-lg .form-control {
   margin-bottom: 10px;
   color: #ffffff;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .form-inline .form-group {
     display: inline-block;
     margin-bottom: 0;
@@ -2803,7 +2803,7 @@ select[multiple].form-group-lg .form-control {
   margin-left: -15px;
   margin-right: -15px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .form-horizontal .control-label {
     text-align: right;
     margin-bottom: 0;
@@ -2813,12 +2813,12 @@ select[multiple].form-group-lg .form-control {
 .form-horizontal .has-feedback .form-control-feedback {
   right: 15px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .form-horizontal .form-group-lg .control-label {
     padding-top: 14.3px;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .form-horizontal .form-group-sm .control-label {
     padding-top: 6px;
   }
@@ -3375,7 +3375,7 @@ tbody.collapse.in {
   bottom: 100%;
   margin-bottom: 1px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-right .dropdown-menu {
     left: auto;
     right: 0;
@@ -3791,7 +3791,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   top: auto;
   left: auto;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .nav-tabs.nav-justified > li {
     display: table-cell;
     width: 1%;
@@ -3809,7 +3809,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs.nav-justified > .active > a:focus {
   border: 1px solid #ddd;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .nav-tabs.nav-justified > li > a {
     border-bottom: 1px solid #ddd;
     border-radius: 4px 4px 0 0;
@@ -3856,7 +3856,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   top: auto;
   left: auto;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .nav-justified > li {
     display: table-cell;
     width: 1%;
@@ -3877,7 +3877,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .nav-tabs-justified > .active > a:focus {
   border: 1px solid #ddd;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .nav-tabs-justified > li > a {
     border-bottom: 1px solid #ddd;
     border-radius: 4px 4px 0 0;
@@ -3907,12 +3907,12 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-bottom: 20px;
   border: 1px solid transparent;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar {
     border-radius: 4px;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-header {
     float: left;
   }
@@ -3928,7 +3928,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-collapse.in {
   overflow-y: auto;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-collapse {
     width: auto;
     border-top: 0;
@@ -3968,7 +3968,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-right: -15px;
   margin-left: -15px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .container > .navbar-header,
   .container-fluid > .navbar-header,
   .container > .navbar-collapse,
@@ -3981,7 +3981,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   z-index: 1000;
   border-width: 0 0 1px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-static-top {
     border-radius: 0;
   }
@@ -3993,7 +3993,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   left: 0;
   z-index: 1030;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-fixed-top,
   .navbar-fixed-bottom {
     border-radius: 0;
@@ -4022,7 +4022,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-brand > img {
   display: block;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar > .container .navbar-brand,
   .navbar > .container-fluid .navbar-brand {
     margin-left: -15px;
@@ -4052,7 +4052,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 .navbar-toggle .icon-bar + .icon-bar {
   margin-top: 4px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-toggle {
     display: none;
   }
@@ -4065,7 +4065,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   padding-bottom: 10px;
   line-height: 20px;
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .navbar-nav .open .dropdown-menu {
     position: static;
     float: none;
@@ -4087,7 +4087,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     background-image: none;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-nav {
     float: left;
     margin: 0;
@@ -4111,7 +4111,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-top: 8px;
   margin-bottom: 8px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-form .form-group {
     display: inline-block;
     margin-bottom: 0;
@@ -4161,7 +4161,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     top: 0;
   }
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .navbar-form .form-group {
     margin-bottom: 5px;
   }
@@ -4169,7 +4169,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
     margin-bottom: 0;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-form {
     width: auto;
     border: 0;
@@ -4208,14 +4208,14 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   margin-top: 15px;
   margin-bottom: 15px;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-text {
     float: left;
     margin-left: 15px;
     margin-right: 15px;
   }
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .navbar-left {
     float: left !important;
   }
@@ -4282,7 +4282,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   background-color: #e7e7e7;
   color: #555;
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .navbar-default .navbar-nav .open .dropdown-menu > li > a {
     color: #777;
   }
@@ -4378,7 +4378,7 @@ fieldset[disabled] .navbar-default .btn-link:focus {
   background-color: #000000;
   color: #fff;
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
     border-color: #000000;
   }
@@ -4459,7 +4459,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
   padding: 6px 12px;
   line-height: 1.42857143;
   text-decoration: none;
-  color: #35818a;
+  color: #5ca2b9;
   background-color: #688591;
   border: 1px solid #ddd;
   margin-left: -1px;
@@ -4479,7 +4479,7 @@ fieldset[disabled] .navbar-inverse .btn-link:focus {
 .pagination > li > span:hover,
 .pagination > li > a:focus,
 .pagination > li > span:focus {
-  color: #204d53;
+  color: #3c788c;
   background-color: #cad4d9;
   border-color: #ddd;
 }
@@ -4711,7 +4711,7 @@ a.badge:focus {
 .jumbotron .container {
   max-width: 100%;
 }
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1100px) {
   .jumbotron {
     padding: 48px 0;
   }
@@ -5627,7 +5627,7 @@ button.close {
   height: 50px;
   overflow: scroll;
 }
-@media (min-width: 768px) {
+@media (min-width: 1100px) {
   .modal-dialog {
     width: 600px;
     margin: 30px auto;
@@ -5640,7 +5640,7 @@ button.close {
     width: 300px;
   }
 }
-@media (min-width: 992px) {
+@media (min-width: 1200px) {
   .modal-lg {
     width: 900px;
   }
@@ -6055,7 +6055,7 @@ button.close {
 .carousel-caption .btn {
   text-shadow: none;
 }
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 1100px) {
   .carousel-control .glyphicon-chevron-left,
   .carousel-control .glyphicon-chevron-right,
   .carousel-control .icon-prev,
@@ -6189,7 +6189,7 @@ button.close {
 .visible-lg-inline-block {
   display: none !important;
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .visible-xs {
     display: block !important;
   }
@@ -6204,22 +6204,22 @@ button.close {
     display: table-cell !important;
   }
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .visible-xs-block {
     display: block !important;
   }
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .visible-xs-inline {
     display: inline !important;
   }
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .visible-xs-inline-block {
     display: inline-block !important;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: 1100px) and (max-width: 1199px) {
   .visible-sm {
     display: block !important;
   }
@@ -6234,22 +6234,22 @@ button.close {
     display: table-cell !important;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: 1100px) and (max-width: 1199px) {
   .visible-sm-block {
     display: block !important;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: 1100px) and (max-width: 1199px) {
   .visible-sm-inline {
     display: inline !important;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: 1100px) and (max-width: 1199px) {
   .visible-sm-inline-block {
     display: inline-block !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 1200px) and (max-width: 1919px) {
   .visible-md {
     display: block !important;
   }
@@ -6264,22 +6264,22 @@ button.close {
     display: table-cell !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 1200px) and (max-width: 1919px) {
   .visible-md-block {
     display: block !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 1200px) and (max-width: 1919px) {
   .visible-md-inline {
     display: inline !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 1200px) and (max-width: 1919px) {
   .visible-md-inline-block {
     display: inline-block !important;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .visible-lg {
     display: block !important;
   }
@@ -6294,37 +6294,37 @@ button.close {
     display: table-cell !important;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .visible-lg-block {
     display: block !important;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .visible-lg-inline {
     display: inline !important;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .visible-lg-inline-block {
     display: inline-block !important;
   }
 }
-@media (max-width: 767px) {
+@media (max-width: 1099px) {
   .hidden-xs {
     display: none !important;
   }
 }
-@media (min-width: 768px) and (max-width: 991px) {
+@media (min-width: 1100px) and (max-width: 1199px) {
   .hidden-sm {
     display: none !important;
   }
 }
-@media (min-width: 992px) and (max-width: 1199px) {
+@media (min-width: 1200px) and (max-width: 1919px) {
   .hidden-md {
     display: none !important;
   }
 }
-@media (min-width: 1200px) {
+@media (min-width: 1920px) {
   .hidden-lg {
     display: none !important;
   }
@@ -6704,7 +6704,6 @@ input[type="checkbox"] {
   background-color: #181E22;
 }
 #chatline {
-  resize: none;
   transition: box-shadow;
   transition-duration: 150ms;
   border: 0;
@@ -6855,7 +6854,4 @@ input[type="checkbox"] {
 #plonotification > div > .btn {
   border: none;
   background-color: #742c00;
-}
-#ch-chat > .form-horizontal > .form-group {
-  margin-bottom: 5px;
 }

--- a/www/css/themes/shale.css
+++ b/www/css/themes/shale.css
@@ -6468,6 +6468,28 @@ svg {
   padding-left: 10px;
   align-content: center;
 }
+/* Navbar is transparent by default */
+.navbar.navbar-inverse.navbar-transparent {
+  transition: background-color 150ms;
+  background-color: transparent;
+}
+/*... but is solid when scrolled */
+.navbar.navbar-inverse.navbar-solid {
+  transition: background-color 150ms;
+  background-color: #070A12;
+}
+/* Nabbar becomes a dropdown at a specific breakpoint; make it no longer transparent */
+#nav-collapsible.collapse.in,
+#nav-collapsible.collapsing {
+  background-color: #070A12;
+  max-height: 100%;
+}
+/* Overriding bootstrap shitty defaults */
+.navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
+.navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
+  background-color: #f5f5f5;
+  color: #212A2E;
+}
 .nav.nav-tabs > li.active > a {
   color: #FDFDFD;
   background-color: #2F3434;

--- a/www/js/coolhole-style.js
+++ b/www/js/coolhole-style.js
@@ -8,10 +8,11 @@ const navbar = document.querySelector(".navbar");
 
 // When we scroll, shift to a solid color once over a Y of 50.
 document.onscroll = () => {
-    navbar.style.setProperty("transition", "background-color 150ms");
-    if (scrollY < 25) {
-        navbar.style.backgroundColor = "transparent";
-    } else {
-        navbar.style.backgroundColor = "#070A12";
-    }
+  if (scrollY < 25) {
+    navbar.classList.remove("navbar-solid");
+    navbar.classList.add("navbar-transparent");
+  } else {
+    navbar.classList.remove("navbar-transparent");
+    navbar.classList.add("navbar-solid");
+  }
 };


### PR DESCRIPTION
Currently:
![image](https://github.com/user-attachments/assets/98c2f37c-5dd2-466d-9668-5f47f7557782)
![image](https://github.com/user-attachments/assets/fcc520d0-9e21-4a02-938e-34f27ec75834)

After variable change in the less file:
![image](https://github.com/user-attachments/assets/184d2072-967f-43d4-ae6e-3a3b263ece5b)
![image](https://github.com/user-attachments/assets/dac0a28a-e062-40f9-b534-065309f1efbf)

Give it a try though. You'll notice that the same breakpoint for the nav bar -> hamburger menu is the same that slips the video under the chat. 