### PR TITLE
fix: don't attempt to run an animation on points user list when it doesn't exist

### DIFF
--- a/src/channel/coolholecommon.js
+++ b/src/channel/coolholecommon.js
@@ -35,7 +35,7 @@ class CoolholeCommonModule extends ChannelModule {
     }
 
     // Process debt effects
-    if (user.getName()) {
+    if (user?.getName()) {
       let debtMsgObj = channel.modules?.coolholepoints.handleChatStatuses(
         user,
         resMsgObj

--- a/src/channel/coolholepoints.js
+++ b/src/channel/coolholepoints.js
@@ -1099,9 +1099,9 @@ class Coolpoints extends ChannelModule {
       // Check if the action is still valid/active. If not, just return since I don't wanna build a hook to start this up again when it's turned on
       const actionStatus = this.isValidAction(
         user.getName(),
-          "active",
-          ActionType.Earnings,
-          "active"
+        "active",
+        ActionType.Earnings,
+        "active"
       );
       if (!actionStatus.success) return;
 

--- a/www/js/coolpoints-util.js
+++ b/www/js/coolpoints-util.js
@@ -350,6 +350,8 @@ function applyPointsToTable(pointData) {
 
   // Run animation
   const userPoints = $(`#${pointData.user}-userlist-points`);
+  if (userPoints.length === 0) return; // If the user's points isn't visible, do nothing
+
   userPoints.text(userCoolPointListItem.points);
   const userPointsMsg = $(`#${pointData.user}-userlist-points-msg`);
   animatePointUpdate(userPoints, userPointsMsg, pointData.points);


### PR DESCRIPTION
`el` is null in `coolpoints-util.js:35` when called by `applyPointsToTable` was showing up intermittently for mod users. Determined it was tied to the animation calls for the user points table missing a check to see if the table + user is even on the DOM at the time of the call