### PR TITLE
increased custom js/css limit from 20k to 500k

### DIFF
--- a/src/channel/customization.js
+++ b/src/channel/customization.js
@@ -116,7 +116,7 @@ CustomizationModule.prototype.handleSetCSS = function (user, data) {
 
     let oldHash = this.cssHash;
     // TODO: consider sending back an error instead of silently truncating
-    this.css = data.css.substring(0, 20000);
+    this.css = data.css.substring(0, 500000); // coolhole: increased from 20000 to 500000
 
     if (oldHash !== this.cssHash) {
         this.dirty = true;
@@ -132,7 +132,7 @@ CustomizationModule.prototype.handleSetJS = function (user, data) {
     }
 
     let oldHash = this.jsHash;
-    this.js = data.js.substring(0, 20000);
+    this.js = data.js.substring(0, 500000); // coolhole: increased from 20000 to 500000
 
     if (oldHash !== this.jsHash) {
         this.dirty = true;

--- a/templates/channeloptions.pug
+++ b/templates/channeloptions.pug
@@ -113,14 +113,14 @@ mixin motdeditor
 mixin csseditor
   #cs-csseditor.tab-pane
     h4 CSS editor
-    p Maximum size 20KB.  If more space is required, use the External CSS option under General Settings to link to an externally hosted stylesheet.
+    p Maximum size 500KB.  If more space is required, use the External CSS option under General Settings to link to an externally hosted stylesheet.
     textarea.form-control#cs-csstext(rows="10")
     button.btn.btn-primary#cs-csssubmit Save CSS
 
 mixin jseditor
   #cs-jseditor.tab-pane
     h4 JS editor
-    p Maximum size 20KB.  If more space is required, use the External JS option under General Settings to link to an externally hosted stylesheet.
+    p Maximum size 500KB.  If more space is required, use the External JS option under General Settings to link to an externally hosted stylesheet.
     textarea.form-control#cs-jstext(rows="10")
     button.btn.btn-primary#cs-jssubmit Save JS
 

--- a/www/js/ui.js
+++ b/www/js/ui.js
@@ -925,14 +925,14 @@ $("#fullscreenbtn").on('click', function () {
 });
 
 function handleCSSJSTooLarge(selector) {
-    if (this.value.length > 20000) {
+    if (this.value.length > 500000) { //coolhole: increased from 20000 to 500000
         let notice = document.querySelector(selector);
         if (notice !== null) {
             return;
         }
 
         notice = makeAlert("Maximum Size Exceeded", "Inline CSS and JavaScript are " +
-                "limited to 20,000 characters or less.  If you need more room, you " +
+                "limited to 500,000 characters or less.  If you need more room, you " +
                 "need to use the external CSS or JavaScript option.", "alert-danger")
                 .attr("id", selector.replace(/#/, ""));
 


### PR DESCRIPTION
Modified the custom js/css to accept 500k bytes instead of cytube's default 20k.
I would have increased it to 2MB like in old prod, but i kept getting "Transport error: Max range exceeded" from socket IO.
Our custom css was ~47k characters long. So 500K should be more than enough.