### PR TITLE
Fix/cp coin image size

### DIFF
--- a/www/css/coolhole.css
+++ b/www/css/coolhole.css
@@ -493,9 +493,12 @@ code.text-lottery {
 
 /* CoolPoints User Styling */
 #cpPromptBtn {
-    grid-gap: 3px;
-    gap: 3px;
     height: 36px;
+}
+
+#cpPromptBtn>span>svg {
+    vertical-align: middle;
+    margin-bottom: 3px;
 }
 
 #cpModal {
@@ -1143,7 +1146,7 @@ code.text-lottery {
 }
 
 .qe_title_disabled {
-  opacity: 0.60;
+    opacity: 0.60;
 }
 
 @keyframes blink {
@@ -1450,4 +1453,55 @@ code.text-lottery {
     100% {
         opacity: 0;
     }
+}
+
+/* polls */
+#pollwrap {
+    padding-left: 0;
+    padding-right: 10px;
+    display: flex;
+    flex-direction: column-reverse;
+}
+
+#pollwrap .well .wrapInner {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 10px;
+}
+
+#pollwrap .well .wrapInner .pollHeader {
+    display: flex;
+    gap: 1.5em;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px;
+}
+
+#pollwrap .well .wrapInner .options {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    align-self: center;
+    padding: 0px 10px 0px 10px;
+}
+
+#pollwrap .well .wrapInner .options .option button {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-right: 0;
+    align-items: center;
+}
+
+#pollwrap .well .wrapInner .options .option button.active {
+    font-weight: bold;
+}
+
+#pollwrap>.well.active {
+    width: 100%;
+    padding: 10px;
+}
+
+#pollwrap>.well.muted {
+    padding: 10px;
 }

--- a/www/css/themes/less/shale/shale.less
+++ b/www/css/themes/less/shale/shale.less
@@ -192,60 +192,19 @@ td>a:hover {
   background-color: #212A2E;
 }
 
-#pollwrap {
-  padding-left: 0;
-  padding-right: 10px;
-  display: flex;
-  flex-direction: column-reverse;
+#pollwrap .well .wrapInner {
+  background: #12151B;
+  
+  .options .option button.active {
+    border: 1px solid #3E97A2;
+  }
 
-  .well {
-    .wrapInner {
-      display: flex;
-      flex-direction: column;
-      background: #12151B;
-      padding-bottom: 10px;
-
-      .pollHeader {
-        display: flex;
-        gap: 1.5em;
-        align-items: center;
-        justify-content: space-between;
-        padding: 10px;
-      }
-
-      .options {
-        display: flex;
-        flex-direction: column;
-        width: 100%;
-        align-self: center;
-        padding: 0px 10px 0px 10px;
-
-        .option {
-          button {
-            display: flex;
-            justify-content: space-between;
-            width: 100%;
-            margin-right: 0;
-            align-items: center;
-          }
-
-          button.active {
-            border: 1px solid #3E97A2;
-            font-weight: bold;
-          }
-
-          button:not(.btn-danger) {
-            background: #212A2E;
-          }
-        }
-      }
-    }
+  .options .option button:not(.btn-danger) {
+    background: #212A2E;
   }
 }
 
 #pollwrap>.well.active {
-  width: 100%;
-  padding: 10px;
   background-color: #181E22;
 
   .btn-default {
@@ -259,7 +218,6 @@ td>a:hover {
 }
 
 #pollwrap>.well.muted {
-  padding: 10px;
   background-color: #1C2124;
 
   .btn-default {

--- a/www/css/themes/less/shale/shale.less
+++ b/www/css/themes/less/shale/shale.less
@@ -40,11 +40,6 @@ td>a:hover {
   color: #799482;
 }
 
-svg {
-  overflow: hidden;
-  vertical-align: middle;
-}
-
 .navbar.navbar-inverse {
   background-color: transparent;
   border: 0;

--- a/www/css/themes/shale.css
+++ b/www/css/themes/shale.css
@@ -6549,49 +6549,16 @@ td > a:hover {
 #motdwrap {
   background-color: #212A2E;
 }
-#pollwrap {
-  padding-left: 0;
-  padding-right: 10px;
-  display: flex;
-  flex-direction: column-reverse;
-}
 #pollwrap .well .wrapInner {
-  display: flex;
-  flex-direction: column;
   background: #12151B;
-  padding-bottom: 10px;
-}
-#pollwrap .well .wrapInner .pollHeader {
-  display: flex;
-  gap: 1.5em;
-  align-items: center;
-  justify-content: space-between;
-  padding: 10px;
-}
-#pollwrap .well .wrapInner .options {
-  display: flex;
-  flex-direction: column;
-  width: 100%;
-  align-self: center;
-  padding: 0px 10px 0px 10px;
-}
-#pollwrap .well .wrapInner .options .option button {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-  margin-right: 0;
-  align-items: center;
 }
 #pollwrap .well .wrapInner .options .option button.active {
   border: 1px solid #3E97A2;
-  font-weight: bold;
 }
 #pollwrap .well .wrapInner .options .option button:not(.btn-danger) {
   background: #212A2E;
 }
 #pollwrap > .well.active {
-  width: 100%;
-  padding: 10px;
   background-color: #181E22;
 }
 #pollwrap > .well.active .btn-default {
@@ -6602,7 +6569,6 @@ td > a:hover {
   color: #212a2e;
 }
 #pollwrap > .well.muted {
-  padding: 10px;
   background-color: #1C2124;
 }
 #pollwrap > .well.muted .btn-default {

--- a/www/css/themes/shale.css
+++ b/www/css/themes/shale.css
@@ -6429,10 +6429,6 @@ td > a {
 td > a:hover {
   color: #799482;
 }
-svg {
-  overflow: hidden;
-  vertical-align: middle;
-}
 .navbar.navbar-inverse {
   background-color: transparent;
   border: 0;

--- a/www/js/coolhole-callbacks.js
+++ b/www/js/coolhole-callbacks.js
@@ -261,7 +261,7 @@ const CoolholeCallbacks = {
         class: "option",
       });
       const optionButton = $("<button>", {
-        class: "btn",
+        class: "btn btn-default",
       });
       optionButton.click(function () {
         if (data.gamble) {


### PR DESCRIPTION
The CP `prompt` button and revised polls had a bunch of styles hand jammed into `slate.less` which caused other themes to look bad:
![image](https://github.com/user-attachments/assets/9ba4de49-1eef-4c91-8272-bf7255edaa35)
_Modern as it looks on 3.0 right now_

Mostly just dumped them into coolhole.css 
Ended up tweaking some styles slightly till it looked good and didn't give it much thought after that. If something "smells" bad, call it out

Here's how each theme looks after the changes:
![image](https://github.com/user-attachments/assets/9095b535-f148-49f4-bf7d-302fad8449ca)
_Light_

![image](https://github.com/user-attachments/assets/157a8ba2-429e-43a4-be57-96ab3c464540)
_Bootstrap_

![image](https://github.com/user-attachments/assets/fece331f-aed4-43a1-a0a4-dc8c844f4b82)
_Slate_

![image](https://github.com/user-attachments/assets/271c238c-bc8e-4c6a-8f44-b521b5e5bc46)
_Shale_

![image](https://github.com/user-attachments/assets/21280d27-1c91-4241-9e2d-fe234b0abb36)
_Cyborg_

![image](https://github.com/user-attachments/assets/4686c095-7428-402e-8057-cdb0582af7d4)
_Modern_